### PR TITLE
Fix ordered comparison between pointer and zero

### DIFF
--- a/tio.cpp
+++ b/tio.cpp
@@ -550,7 +550,7 @@ QString CCharsetMagic::guess_for_file (const QString &fname)
      for (vector <size_t>::size_type i = 0; i < signatures.size(); i++)
           for (int x = 0; x < signatures[i]->words.count(); x++)
               {
-               if (bafile.contains (signatures[i]->words[x]) > 0)
+               if (bafile.contains (signatures[i]->words[x]))
                   {
                    enc = signatures[i]->encname;
                    return enc;


### PR DESCRIPTION
Hi, tea 50.0.4 fails to build when using newer compilers, like the version of clang included by Apple in Xcode 10 or later (as [reported to MacPorts](https://trac.macports.org/ticket/60801)) or a newer open-source clang such as clang 9.0.1 when used on any system:

```
/opt/local/bin/clang++-mp-9.0 -c -Os -stdlib=libc++ -arch x86_64 -O2 -Wall -W -DVERSION_NUMBER=\"50.0.4\" -DNOCRYPT -DNOUNCRYPT -DQUAZIP_STATIC -DPRINTER_ENABLE -DASPELL_ENABLE -DHUNSPELL_ENABLE -DQT_NO_DEBUG -DQT_GUI_LIB -DQT_CORE_LIB -DQT_SHARED -I/opt/local/libexec/qt4/share/mkspecs/macx-g++ -I. -I. -I/opt/local/libexec/qt4/Library/Frameworks/QtCore.framework/Versions/4/Headers -I/opt/local/libexec/qt4/Library/Frameworks/QtGui.framework/Versions/4/Headers -I/opt/local/include/hunspell -I/opt/local/libexec/qt4/Library/Frameworks/QtGui.framework/Versions/4/Headers -I/opt/local/libexec/qt4/Library/Frameworks/QtCore.framework/Versions/4/Headers -I/opt/local/libexec/qt4/include -F/opt/local/libexec/qt4/Library/Frameworks -F/opt/local/libexec/qt4/lib -o tio.o tio.cpp
tio.cpp:268:41: warning: unused parameter 'fname' [-Wunused-parameter]
bool CTioReadOnly::save (const QString &fname)
                                        ^
tio.cpp:553:62: error: ordered comparison between pointer and zero ('const void *' and 'int')
               if (bafile.contains (signatures[i]->words[x]) > 0)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
1 warning and 1 error generated.
make: *** [tio.o] Error 1
```

This type of error has come up in many other projects and we've fixed it in similar ways.

I'm a little confused by the way it's appearing here, because QByteArray's contains method is documented to return a bool, not a const void *. But this change does fix the problem for me and makes it match how you use the contains method elsewhere in tea.