### PR TITLE
Add syntax highlighting for PRQL

### DIFF
--- a/hls/prql.xml
+++ b/hls/prql.xml
@@ -1,0 +1,31 @@
+<document pattern="^.*\.(prql)$">
+
+<item name="options" wrap="0"></item>
+
+<item name="keywords" type="keywords" color="keywords" fontstyle="bold">
+\b(let|module|prql|false|null|true|this|that)\b</item>
+
+<item name="functions" type="keywords" color="functions">
+\b(aggregate|derive|filter|from|group|join|select|sort|take|window)\b</item>
+
+<item name="types" type="keywords" color="type">\b(int(8|16|32|64|128)?|float(32|64)|bool|text|date|time|timestamp)\b</item>
+
+<item name="operator" type="item" color="operator">[~-=\+\*\/\|]</item>
+
+<item name="bracket" type="item" color="brackets">[\(\)\[\]]</item>
+
+<item name="quotes" type="item" color="quotes">("[^\"]*"|'[^']*')</item>
+
+<item name="char" type="item" color="quotes">('[^']*')</item>
+
+<item name="single comment" type="item" color="single comment" fontstyle="italic">#[^\n]*</item>
+
+<item name="mcomment-start" type="mcomment-start" color="mcomment-start" fontstyle="italic">"""</item>
+
+<item name="mcomment-end" type="mcomment-end">"""</item>
+
+<item name="cm_mult" type="comment">"""%s\n"""</item>
+
+<item name="cm_single" type="comment">#/%s</item>
+
+</document>

--- a/resources.qrc
+++ b/resources.qrc
@@ -87,6 +87,7 @@
     <file>hls/lout.xml</file>
     <file>hls/lua.xml</file>
     <file>hls/perl.xml</file>
+    <file>hls/prql.xml</file>
     <file>hls/vala.xml</file>
     <file>hls/bash.xml</file>
     <file>hls/nasm.xml</file>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -583,6 +583,7 @@ CFTypeChecker::CFTypeChecker()
   ADDTEXTTYPE ("^.*\\.(pl|pm)$");
   ADDTEXTTYPE ("^.*\\.(php)$");
   ADDTEXTTYPE ("^.*\\.(po)$");
+  ADDTEXTTYPE ("^.*\\.(prql)$");
   ADDTEXTTYPE ("^.*\\.(py)$");
   ADDTEXTTYPE ("^.*\\.(r)$");
   ADDTEXTTYPE ("^.*\\.(sd7)$");
@@ -629,6 +630,7 @@ CFTypeChecker::CFTypeChecker()
   patterns.push_back (QRegExp ("^.*\\.(pl|pm)$", Qt::CaseInsensitive));
   patterns.push_back (QRegExp ("^.*\\.(php)$", Qt::CaseInsensitive));
   patterns.push_back (QRegExp ("^.*\\.(po)$", Qt::CaseInsensitive));
+  patterns.push_back (QRegExp ("^.*\\.(pqrl)$", Qt::CaseInsensitive));
   patterns.push_back (QRegExp ("^.*\\.(py)$", Qt::CaseInsensitive));
   patterns.push_back (QRegExp ("^.*\\.(r)$", Qt::CaseInsensitive));
   patterns.push_back (QRegExp ("^.*\\.(sd7)$", Qt::CaseInsensitive));
@@ -668,6 +670,7 @@ CFTypeChecker::CFTypeChecker()
   patterns.push_back (QRegularExpression ("^.*\\.(pl|pm)$", QRegularExpression::CaseInsensitiveOption));
   patterns.push_back (QRegularExpression ("^.*\\.(php)$", QRegularExpression::CaseInsensitiveOption));
   patterns.push_back (QRegularExpression ("^.*\\.(po)$", QRegularExpression::CaseInsensitiveOption));
+  patterns.push_back (QRegularExpression ("^.*\\.(prql)$", QRegularExpression::CaseInsensitiveOption));
   patterns.push_back (QRegularExpression ("^.*\\.(py)$", QRegularExpression::CaseInsensitiveOption));
   patterns.push_back (QRegularExpression ("^.*\\.(r)$", QRegularExpression::CaseInsensitiveOption));
   patterns.push_back (QRegularExpression ("^.*\\.(sd7)$", QRegularExpression::CaseInsensitiveOption));


### PR DESCRIPTION
PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.

https://prql-lang.org/
https://github.com/PRQL/prql